### PR TITLE
Add: FallbackLocale support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Version [7.2.1][unreleased] - (in development)
-- stay tuned ...
+- New: Fallback locales.
 
 ## Version [7.2.0] - (2016-11-10)
 - Added: Limited sync support for Preview endpoint (Only `inital=true!`)

--- a/src/main/java/com/contentful/java/cda/CDALocale.java
+++ b/src/main/java/com/contentful/java/cda/CDALocale.java
@@ -10,6 +10,9 @@ public class CDALocale implements Serializable {
 
   String name;
 
+  @SerializedName("fallbackCode")
+  String fallbackLocaleCode;
+
   @SerializedName("default")
   boolean defaultLocale;
 
@@ -21,6 +24,11 @@ public class CDALocale implements Serializable {
   /** Name */
   public String name() {
     return name;
+  }
+
+  /** Fallback code */
+  public String fallbackLocaleCode() {
+    return fallbackLocaleCode;
   }
 
   /** Default */

--- a/src/main/java/com/contentful/java/cda/LocalizedResource.java
+++ b/src/main/java/com/contentful/java/cda/LocalizedResource.java
@@ -8,6 +8,8 @@ public abstract class LocalizedResource extends CDAResource {
 
   String defaultLocale;
 
+  Map<String, String> fallbackLocaleMap;
+
   Map<String, Object> fields;
 
   Map<String, Object> rawFields;
@@ -20,15 +22,25 @@ public abstract class LocalizedResource extends CDAResource {
    */
   @SuppressWarnings("unchecked")
   public <T> T getField(String key) {
-    Map<?, ?> value = (Map<? ,?>) fields.get(key);
+    final Map<String, T> value = (Map<String ,T>) fields.get(key);
     if (value == null) {
       return null;
     }
-    Object localized = value.get(locale);
-    if (localized != null) {
-      return (T) localized;
+
+    return getFieldForFallbackLocale(value, locale);
+  }
+
+  private <T> T getFieldForFallbackLocale(Map<String, T> value, String locale) {
+    if (locale == null) {
+      return null;
     }
-    return (T) value.get(defaultLocale);
+
+    final T localized = value.get(locale);
+    if (localized != null) {
+      return localized;
+    } else {
+      return getFieldForFallbackLocale(value, fallbackLocaleMap.get(locale));
+    }
   }
 
   /** Raw unprocessed fields. */
@@ -44,6 +56,14 @@ public abstract class LocalizedResource extends CDAResource {
   /** Switches the locale to the one matching the given locale code. */
   public void setLocale(String locale) {
     this.locale = locale;
+  }
+
+  void setFallbackLocaleMap(Map<String, String> fallbackLocaleMap) {
+    this.fallbackLocaleMap = fallbackLocaleMap;
+  }
+
+  Map<String, String> fallbackLocaleMap() {
+    return fallbackLocaleMap;
   }
 
   void setDefaultLocale(String defaultLocale) {

--- a/src/main/java/com/contentful/java/cda/ResourceUtils.java
+++ b/src/main/java/com/contentful/java/cda/ResourceUtils.java
@@ -222,6 +222,7 @@ final class ResourceUtils {
 
   static void localize(LocalizedResource resource, CDASpace space) {
     resource.setDefaultLocale(space.defaultLocale().code());
+    resource.setFallbackLocaleMap(getFallbackLocaleMap(space));
     String resourceLocale = resource.getAttribute("locale");
     if (resourceLocale == null) {
       // sync
@@ -231,6 +232,19 @@ final class ResourceUtils {
       resource.setLocale(resourceLocale);
       normalizeFields(resource);
     }
+  }
+
+  private static Map<String, String> getFallbackLocaleMap(CDASpace space) {
+    final Map<String, String> fallbackLocales = new HashMap<String, String>(space.locales().size());
+
+    for (final CDALocale locale : space.locales()) {
+      final String fallback = locale.fallbackLocaleCode();
+      if (fallback != null && !"".equals(fallback)) {
+        fallbackLocales.put(locale.code, fallback);
+      }
+    }
+
+    return fallbackLocales;
   }
 
   static void normalizeFields(LocalizedResource resource) {

--- a/src/test/java/com/contentful/java/cda/EntryTest.java
+++ b/src/test/java/com/contentful/java/cda/EntryTest.java
@@ -22,7 +22,7 @@ public class EntryTest extends BaseTest {
   @Test
   @Enqueue("array_empty.json")
   public void fetchNonExistingEntryEmitsNull() throws Exception {
-    final Object result[] = new Object[] { new Object() };
+    final Object result[] = new Object[]{new Object()};
     final CountDownLatch latch = new CountDownLatch(1);
     assertThat(client.observe(CDAEntry.class)
         .one("foo")
@@ -72,7 +72,7 @@ public class EntryTest extends BaseTest {
   @Enqueue("demo/entries_nyancat.json")
   public void fetchEntryAsync() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
-    final CDAEntry[] result = { null };
+    final CDAEntry[] result = {null};
 
     client.fetch(CDAEntry.class).one("nyancat", new CDACallback<CDAEntry>() {
       @Override protected void onSuccess(CDAEntry entry) {
@@ -127,14 +127,13 @@ public class EntryTest extends BaseTest {
 
     // Localization
     assertThat(entry.locale()).isEqualTo("en-US");
-    entry.setLocale("tlh");
     assertThat(entry.getField("color")).isEqualTo("rainbow");
     assertThat(entry.getField("non-existing-does-not-throw")).isNull();
   }
 
   @Test
   @Enqueue(
-      defaults = { "arrays/space.json", "arrays/content_types.json" },
+      defaults = {"arrays/space.json", "arrays/content_types.json"},
       value = "arrays/entries.json"
   )
   public void arrayItemsContainOnlyTopLevelEntries() throws Exception {

--- a/src/test/java/com/contentful/java/cda/LocaleFallbackTest.java
+++ b/src/test/java/com/contentful/java/cda/LocaleFallbackTest.java
@@ -1,0 +1,119 @@
+package com.contentful.java.cda;
+
+import com.contentful.java.cda.lib.Enqueue;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class LocaleFallbackTest extends BaseTest {
+  @Test
+  @Enqueue(value = "locales/space.json", defaults = {})
+  public void fetchLocales() throws Exception {
+    final CDASpace space = client.fetchSpace();
+
+    final List<CDALocale> locales = space.locales;
+    Map<String, CDALocale> localesByCodeMap = listToMapByNamer(locales, localeNamer);
+
+    assertThat(localesByCodeMap).hasSize(4);
+    assertThat(localesByCodeMap.get("default").fallbackLocaleCode()).isNull();
+    assertThat(localesByCodeMap.get("default").isDefaultLocale()).isTrue();
+
+    assertThat(localesByCodeMap.get("first").fallbackLocaleCode()).isEqualTo("inbetween");
+
+    assertThat(localesByCodeMap.get("inbetween").fallbackLocaleCode()).isEqualTo("default");
+
+    assertThat(localesByCodeMap.get("null").fallbackLocaleCode()).isNull();
+  }
+
+  @Test
+  @Enqueue(
+      defaults = {"locales/space.json", "locales/content_types.json"},
+      value = "locales/entries.json"
+  )
+  public void testFallbackLocaleQueueToDefaultOneHop() throws Exception {
+    final CDAArray all = client.fetch(CDAEntry.class).all();
+    final Map<String, CDAEntry> entries = all.entries();
+
+    final CDAEntry nofirst = entries.get("no-first");
+    assertThat(nofirst.getField("title")).isEqualTo("no-first");
+
+    nofirst.setLocale("first");
+    assertThat(nofirst.getField("title")).isEqualTo("inbetween");
+
+    nofirst.setLocale("inbetween");
+    assertThat(nofirst.getField("title")).isEqualTo("inbetween");
+
+    nofirst.setLocale("default");
+    assertThat(nofirst.getField("title")).isEqualTo("no-first");
+  }
+
+  @Test
+  @Enqueue(
+      defaults = {"locales/space.json", "locales/content_types.json"},
+      value = "locales/entries.json"
+  )
+  public void testFallbackLocaleQueueToDefaultTwoHops() throws Exception {
+    final CDAArray all = client.fetch(CDAEntry.class).all();
+    final Map<String, CDAEntry> entries = all.entries();
+
+    final CDAEntry noFirstAndNoInBetween = entries.get("no-first-and-no-inbetween");
+    assertThat(noFirstAndNoInBetween.getField("title")).isEqualTo("no-first-and-no-inbetween");
+
+    noFirstAndNoInBetween.setLocale("first");
+    assertThat(noFirstAndNoInBetween.getField("title")).isEqualTo("no-first-and-no-inbetween");
+
+    noFirstAndNoInBetween.setLocale("inbetween");
+    assertThat(noFirstAndNoInBetween.getField("title")).isEqualTo("no-first-and-no-inbetween");
+
+    noFirstAndNoInBetween.setLocale("default");
+    assertThat(noFirstAndNoInBetween.getField("title")).isEqualTo("no-first-and-no-inbetween");
+  }
+
+  @Test
+  @Enqueue(
+      defaults = {"locales/space.json", "locales/content_types.json"},
+      value = "locales/entries.json"
+  )
+  public void testFallbackLocaleQueueToNull() throws Exception {
+    final CDAArray all = client.fetch(CDAEntry.class).all();
+    final Map<String, CDAEntry> entries = all.entries();
+
+    final CDAEntry toNull = entries.get("no-null");
+    assertThat(toNull.getField("title")).isEqualTo("no-null");
+
+    toNull.setLocale("null");
+    assertThat(toNull.getField("title")).isNull();
+  }
+
+
+  private static Namer<CDALocale> localeNamer = new Namer<CDALocale>() {
+    @Override public String name(CDALocale cdaLocale) {
+      return cdaLocale.code();
+    }
+  };
+
+  private interface Namer<T> {
+    String name(T t);
+  }
+
+  private <T> Map<String, T> listToMapByNamer(List<T> list, Namer<T> namer) {
+    final HashMap<String, T> map = new HashMap<String, T>();
+
+    for (T item : list) {
+      final String key = namer.name(item);
+      if (map.containsKey(key)) {
+        throw new IllegalStateException("Locale Code should not be present twice!");
+      }
+
+      map.put(key, item);
+    }
+
+    return map;
+  }
+
+}

--- a/src/test/resources/demo/space.json
+++ b/src/test/resources/demo/space.json
@@ -13,7 +13,8 @@
     {
       "code": "tlh",
       "default": false,
-      "name": "Klingon"
+      "name": "Klingon",
+      "fallbackCode": "en-US"
     }
   ]
 }

--- a/src/test/resources/links/space.json
+++ b/src/test/resources/links/space.json
@@ -13,7 +13,8 @@
     {
       "code": "he-IL",
       "default": false,
-      "name": "Hebrew"
+      "name": "Hebrew",
+      "fallback": "en-US"
     }
   ]
 }

--- a/src/test/resources/links_invalid/space.json
+++ b/src/test/resources/links_invalid/space.json
@@ -13,7 +13,8 @@
     {
       "code": "es",
       "default": false,
-      "name": "Spanish"
+      "name": "Spanish",
+      "fallback": "en-US"
     }
   ]
 }

--- a/src/test/resources/locales/content_types.json
+++ b/src/test/resources/locales/content_types.json
@@ -1,0 +1,40 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "7dh3w86is8ls"
+          }
+        },
+        "id": "sampleType",
+        "type": "ContentType",
+        "createdAt": "2016-06-21T08:53:55.767Z",
+        "updatedAt": "2016-06-21T13:16:34.507Z",
+        "revision": 5
+      },
+      "displayField": "title",
+      "name": "Sample Type",
+      "description": "af → zu-ZA →en-US*\nne-NP  → NULL\nbs_BA⁰ → en-US*\n\n(→if not found, look at the following locale)\n(* = default locale)\n(⁰ = can include empty elements)\n(NULL = No default)",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/locales/entries.json
+++ b/src/test/resources/locales/entries.json
@@ -1,0 +1,129 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 5,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "7dh3w86is8ls"
+          }
+        },
+        "id": "no-null",
+        "type": "Entry",
+        "createdAt": "2016-07-04T15:58:21.612Z",
+        "updatedAt": "2016-07-04T15:58:21.612Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "sampleType"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "first": "first",
+          "default": "no-null",
+          "inbetween": "inbetween"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "7dh3w86is8ls"
+          }
+        },
+        "id": "no-inbetween",
+        "type": "Entry",
+        "createdAt": "2016-07-04T15:58:22.577Z",
+        "updatedAt": "2016-07-04T15:58:22.577Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "sampleType"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "first": "first",
+          "default": "no-inbetween",
+          "null": "null"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "7dh3w86is8ls"
+          }
+        },
+        "id": "no-first-and-no-inbetween",
+        "type": "Entry",
+        "createdAt": "2016-07-04T16:10:28.180Z",
+        "updatedAt": "2016-07-05T13:22:00.251Z",
+        "revision": 2,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "sampleType"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "default": "no-first-and-no-inbetween",
+          "null": "null"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "7dh3w86is8ls"
+          }
+        },
+        "id": "no-first",
+        "type": "Entry",
+        "createdAt": "2016-07-04T15:58:19.645Z",
+        "updatedAt": "2016-07-04T15:58:19.645Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "sampleType"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "default": "no-first",
+          "null": "null",
+          "inbetween": "inbetween"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/locales/space.json
+++ b/src/test/resources/locales/space.json
@@ -1,0 +1,33 @@
+{
+  "sys": {
+    "type": "Space",
+    "id": "7dh3w86is8ls"
+  },
+  "name": "Fallback Locales",
+  "locales": [
+    {
+      "code": "default",
+      "default": true,
+      "name": "default locale",
+      "fallbackCode": null
+    },
+    {
+      "code": "first",
+      "default": false,
+      "name": "first locale",
+      "fallbackCode": "inbetween"
+    },
+    {
+      "code": "inbetween",
+      "default": false,
+      "name": "inbetween locale",
+      "fallbackCode": "default"
+    },
+    {
+      "code": "null",
+      "default": false,
+      "name": "locale with fallback set to null",
+      "fallbackCode": null
+    }
+  ]
+}


### PR DESCRIPTION
Add support for upcomming fallback support for locales, enabling chaining of locales.
Fields can now contain Null if the fallback locale was explicitly set to null on
Contentful.

Changes might only apply if fallback locale was explicitly changed.
