### PR TITLE
Add initial sync on preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Version [7.1.1][unreleased] - (in development)
+## Version [7.2.1][unreleased] - (in development)
 - stay tuned ...
 
-## Version [7.1.0][unreleased] - (2016-11-01)
+## Version [7.2.0] - (2016-11-10)
+- Added: Limited sync support for Preview endpoint (Only `inital=true!`)
+
+## Version [7.1.0] - (2016-11-01)
 - Added: Clear java cache through `CMAClient`
 
 ## Version [7.0.2] - (2016-07-08)
@@ -144,7 +147,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Version 1.0.0 - 2014-08-13
 Initial release.
 
-[unreleased]: https://github.com/contentful/contentful.java/compare/java-sdk-7.1.1...HEAD
+[unreleased]: https://github.com/contentful/contentful.java/compare/java-sdk-7.2.1...HEAD
+[7.2.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.1.0...java-sdk-7.2.0
 [7.1.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.0.2...java-sdk-7.1.0
 [7.0.2]: https://github.com/contentful/contentful.java/compare/java-sdk-7.0.1...java-sdk-7.0.2
 [7.0.1]: https://github.com/contentful/contentful.java/compare/java-sdk-7.0.0...java-sdk-7.0.1

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Grab via Maven:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>7.0.2</version>
+  <version>7.2.0</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.contentful.java:java-sdk:7.0.2'
+compile 'com.contentful.java:java-sdk:7.2.0'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
@@ -126,7 +126,7 @@ Copyright (c) 2016 Contentful GmbH. See [LICENSE.txt][6] for further details.
 
 
  [1]: https://www.contentful.com
- [2]: https://oss.sonatype.org/service/local/repositories/releases/content/com/contentful/java/java-sdk/7.1.0/java-sdk-7.1.0.jar
+ [2]: https://oss.sonatype.org/service/local/repositories/releases/content/com/contentful/java/java-sdk/7.2.0/java-sdk-7.2.0.jar
  [3]: https://contentful.github.io/contentful.java/
  [4]: https://www.contentful.com/developers/documentation/content-delivery-api/
  [5]: https://square.github.io/okhttp/

--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -147,7 +147,6 @@ public class CDAClient {
    * Returns a {@link SyncQuery} for initial synchronization via the Sync API.
    *
    * @return query instance.
-   * @throws UnsupportedOperationException if tried to sync with a preview token
    */
   public SyncQuery sync() {
     return sync(null, null);
@@ -157,9 +156,10 @@ public class CDAClient {
    * Returns a {@link SyncQuery} for synchronization with the provided {@code syncToken} via
    * the Sync API.
    *
+   * If called from a {@link #preview} client, this will always do an initial sync.
+   *
    * @param syncToken sync token.
    * @return query instance.
-   * @throws UnsupportedOperationException if tried to sync with a preview token
    */
   public SyncQuery sync(String syncToken) {
     return sync(syncToken, null);
@@ -168,9 +168,10 @@ public class CDAClient {
   /**
    * Returns a {@link SyncQuery} for synchronization with an existing space.
    *
+   * If called from a {@link #preview} client, this will always do an initial sync.
+   *
    * @param synchronizedSpace space to sync.
    * @return query instance.
-   * @throws UnsupportedOperationException if tried to sync with a preview token
    */
   public SyncQuery sync(SynchronizedSpace synchronizedSpace) {
     return sync(null, synchronizedSpace);
@@ -178,7 +179,8 @@ public class CDAClient {
 
   private SyncQuery sync(String syncToken, SynchronizedSpace synchronizedSpace) {
     if (preview) {
-      throw new UnsupportedOperationException("Syncing using a preview token is not supported. Please use a production token.");
+      syncToken = null;
+      synchronizedSpace = null;
     }
 
     SyncQuery.Builder builder = SyncQuery.builder().setClient(this);

--- a/src/main/java/com/contentful/java/cda/ResourceUtils.java
+++ b/src/main/java/com/contentful/java/cda/ResourceUtils.java
@@ -150,7 +150,7 @@ final class ResourceUtils {
   }
 
   static CDAResource findLinkedResource(ArrayResource array, CDAType linkType,
-      String id) {
+                                        String id) {
     if (ASSET.equals(linkType)) {
       return array.assets().get(id);
     } else if (ENTRY.equals(linkType)) {
@@ -160,7 +160,7 @@ final class ResourceUtils {
   }
 
   static void mapResources(Collection<? extends CDAResource> resources,
-      Map<String, CDAAsset> assets, Map<String, CDAEntry> entries) {
+                           Map<String, CDAAsset> assets, Map<String, CDAEntry> entries) {
     for (CDAResource resource : resources) {
       CDAType type = resource.type();
       String id = resource.id();
@@ -239,12 +239,20 @@ final class ResourceUtils {
       Object value = resource.fields.get(key);
       if (value == null) {
         continue;
+      } else if (resourceContainsLocaleMap(resource, value)) {
+        fields.put(key, value);
+      } else {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put(resource.locale(), value);
+        fields.put(key, map);
       }
-      Map<String, Object> map = new HashMap<String, Object>();
-      map.put(resource.locale(), value);
-      fields.put(key, map);
     }
     resource.fields = fields;
+  }
+
+  private static boolean resourceContainsLocaleMap(LocalizedResource resource, Object value) {
+    return value instanceof Map
+        && ((Map) value).containsKey(resource.locale);
   }
 
   static void setRawFields(ArrayResource array) {

--- a/src/test/java/com/contentful/java/cda/BaseTest.java
+++ b/src/test/java/com/contentful/java/cda/BaseTest.java
@@ -56,6 +56,7 @@ public class BaseTest {
   protected CDAClient createPreviewClient() {
     return createBuilder()
         .preview()
+        .setEndpoint(serverUrl())
         .build();
   }
 

--- a/src/test/java/com/contentful/java/cda/SyncTest.java
+++ b/src/test/java/com/contentful/java/cda/SyncTest.java
@@ -135,7 +135,7 @@ public class SyncTest extends BaseTest {
 
   @Test
   @Enqueue(
-      defaults = { },
+      defaults = {},
       value = {
           "links_invalid/space.json",
           "links_invalid/content_types.json",
@@ -146,10 +146,43 @@ public class SyncTest extends BaseTest {
     client.sync().fetch();
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  @Enqueue({"links_invalid/preview_space.json"})
-  public void syncingWithPreviewTokenThrows() throws Exception {
+  @Test @Enqueue({
+      "demo/sync_initial_preview_p1.json", "demo/sync_initial_preview_p2.json",
+      "demo/space.json", "demo/content_types.json"
+  })
+  public void syncingInPreviewWithTokenSyncsInitial() throws Exception {
     client = createPreviewClient();
-    client.sync().fetch();
+
+    final SynchronizedSpace space = client.sync("sometoken").fetch();
+    assertInitial(space);
+  }
+
+  @Test
+  @Enqueue({
+      "demo/sync_initial_preview_p1.json", "demo/sync_initial_preview_p2.json",
+      "demo/space.json", "demo/content_types.json",
+      "demo/sync_initial_preview_p1.json", "demo/sync_initial_preview_p2.json",
+      "demo/space.json", "demo/content_types.json"
+  })
+  public void syncingInPreviewWithPreviousSpaceSyncsInitial() throws Exception {
+    client = createPreviewClient();
+
+    SynchronizedSpace space = client.sync().fetch();
+    assertInitial(space);
+
+    space = client.sync(space).fetch();
+    assertInitial(space);
+  }
+
+  @Test
+  @Enqueue({
+      "demo/sync_initial_preview_p1.json",
+      "demo/sync_initial_preview_p2.json",
+      "demo/space.json"})
+  public void syncingWithPreviewWorks() throws Exception {
+    client = createPreviewClient();
+    final SynchronizedSpace space = client.sync().fetch();
+
+    assertInitial(space);
   }
 }

--- a/src/test/resources/demo/sync_initial_preview_p1.json
+++ b/src/test/resources/demo/sync_initial_preview_p1.json
@@ -1,0 +1,43 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "1t9IbcfdCk6m04uISSsaIK"
+          }
+        },
+        "id": "5ETMRzkl9KM4omyMwKAOki",
+        "revision": 3,
+        "createdAt": "2014-02-21T13:42:57.752Z",
+        "updatedAt": "2014-08-23T14:42:35.207Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": {
+          "en-US": "London"
+        },
+        "center": {
+          "en-US": {
+            "lat": 51.508515,
+            "lon": -0.12548719999995228
+          }
+        }
+      }
+    }
+  ],
+  "nextPageUrl": "http://cdn.contentful.com/spaces/cfexampleapi/sync?sync_token=foo"
+}

--- a/src/test/resources/demo/sync_initial_preview_p2.json
+++ b/src/test/resources/demo/sync_initial_preview_p2.json
@@ -1,0 +1,580 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "1t9IbcfdCk6m04uISSsaIK"
+          }
+        },
+        "id": "7qVBlCjpWE86Oseo40gAEY",
+        "revision": 2,
+        "createdAt": "2014-02-21T13:43:38.258Z",
+        "updatedAt": "2014-04-15T08:22:22.010Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": {
+          "en-US": "San Francisco"
+        },
+        "center": {
+          "en-US": {
+            "lat": 37.7749295,
+            "lon": -122.41941550000001
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "1t9IbcfdCk6m04uISSsaIK"
+          }
+        },
+        "id": "ge1xHyH3QOWucKWCCAgIG",
+        "revision": 1,
+        "createdAt": "2014-02-21T13:43:23.210Z",
+        "updatedAt": "2014-02-21T13:43:23.210Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": {
+          "en-US": "Paris"
+        },
+        "center": {
+          "en-US": {
+            "lat": 48.856614,
+            "lon": 2.3522219000000177
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "1t9IbcfdCk6m04uISSsaIK"
+          }
+        },
+        "id": "4MU1s3potiUEM2G4okYOqw",
+        "revision": 1,
+        "createdAt": "2014-02-21T13:42:45.926Z",
+        "updatedAt": "2014-02-21T13:42:45.926Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": {
+          "en-US": "Berlin"
+        },
+        "center": {
+          "en-US": {
+            "lat": 52.52000659999999,
+            "lon": 13.404953999999975
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Asset",
+        "id": "1x0xpXu4pSGS4OukSyWGUK",
+        "revision": 6,
+        "createdAt": "2013-11-06T09:45:10.000Z",
+        "updatedAt": "2013-12-18T13:27:14.917Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "title": {
+          "en-US": "Doge"
+        },
+        "file": {
+          "en-US": {
+            "fileName": "doge.jpg",
+            "contentType": "image/jpeg",
+            "details": {
+              "image": {
+                "width": 5800,
+                "height": 4350
+              },
+              "size": 522943
+            },
+            "url": "//images.contentful.com/cfexampleapi/1x0xpXu4pSGS4OukSyWGUK/cc1239c6385428ef26f4180190532818/doge.jpg"
+          }
+        },
+        "description": {
+          "en-US": "nice picture"
+        }
+      }
+    },
+    {
+      "fields": {
+        "name": {
+          "en-US": "Jake"
+        },
+        "description": {
+          "en-US": "Bacon pancakes, makin' bacon pancakes!"
+        },
+        "image": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "jake"
+            }
+          }
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "dog"
+          }
+        },
+        "id": "jake",
+        "revision": 5,
+        "createdAt": "2013-06-27T22:46:22.096Z",
+        "updatedAt": "2013-12-18T13:10:26.212Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "fields": {
+        "name": {
+          "en-US": "Happy Cat",
+          "tlh": "Quch vIghro'"
+        },
+        "bestFriend": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "nyancat"
+            }
+          }
+        },
+        "likes": {
+          "en-US": [
+            "cheezburger"
+          ]
+        },
+        "color": {
+          "en-US": "gray"
+        },
+        "birthday": {
+          "en-US": "2003-10-28T23:00:00+00:00"
+        },
+        "lives": {
+          "en-US": 1
+        },
+        "image": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "happycat"
+            }
+          }
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "cat"
+          }
+        },
+        "id": "happycat",
+        "revision": 8,
+        "createdAt": "2013-06-27T22:46:20.171Z",
+        "updatedAt": "2013-11-18T15:58:02.018Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "dog"
+          }
+        },
+        "id": "6KntaYXaHSyIw8M6eo26OK",
+        "revision": 2,
+        "createdAt": "2013-11-06T09:45:27.475Z",
+        "updatedAt": "2013-11-18T09:13:37.808Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": {
+          "en-US": "Doge"
+        },
+        "image": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "1x0xpXu4pSGS4OukSyWGUK"
+            }
+          }
+        },
+        "description": {
+          "en-US": "such json\nwow"
+        }
+      }
+    },
+    {
+      "fields": {
+        "name": {
+          "en-US": "Finn"
+        },
+        "description": {
+          "en-US": "Fearless adventurer! Defender of pancakes."
+        },
+        "likes": {
+          "en-US": [
+            "adventure"
+          ]
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "human"
+          }
+        },
+        "id": "finn",
+        "revision": 6,
+        "createdAt": "2013-06-27T22:46:21.450Z",
+        "updatedAt": "2013-09-09T16:15:01.297Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "fields": {
+        "name": {
+          "en-US": "Nyan Cat",
+          "tlh": "Nyan vIghro'"
+        },
+        "likes": {
+          "en-US": [
+            "rainbows",
+            "fish"
+          ]
+        },
+        "color": {
+          "en-US": "rainbow"
+        },
+        "bestFriend": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "happycat"
+            }
+          }
+        },
+        "birthday": {
+          "en-US": "2011-04-04T22:00:00+00:00"
+        },
+        "lives": {
+          "en-US": 1337
+        },
+        "image": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "nyancat"
+            }
+          }
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "cat"
+          }
+        },
+        "id": "nyancat",
+        "revision": 5,
+        "createdAt": "2013-06-27T22:46:19.513Z",
+        "updatedAt": "2013-09-04T09:19:39.027Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "fields": {
+        "title": {
+          "en-US": "Jake"
+        },
+        "file": {
+          "en-US": {
+            "fileName": "jake.png",
+            "contentType": "image/png",
+            "details": {
+              "image": {
+                "width": 100,
+                "height": 161
+              },
+              "size": 20480
+            },
+            "url": "//images.contentful.com/cfexampleapi/4hlteQAXS8iS0YCMU6QMWg/2a4d826144f014109364ccf5c891d2dd/jake.png"
+          }
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Asset",
+        "id": "jake",
+        "revision": 2,
+        "createdAt": "2013-09-02T14:56:34.260Z",
+        "updatedAt": "2013-09-02T15:22:39.466Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "fields": {
+        "file": {
+          "en-US": {
+            "fileName": "happycatw.jpg",
+            "contentType": "image/jpeg",
+            "details": {
+              "image": {
+                "width": 273,
+                "height": 397
+              },
+              "size": 59939
+            },
+            "url": "//images.contentful.com/cfexampleapi/3MZPnjZTIskAIIkuuosCss/382a48dfa2cb16c47aa2c72f7b23bf09/happycatw.jpg"
+          }
+        },
+        "title": {
+          "en-US": "Happy Cat"
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Asset",
+        "id": "happycat",
+        "revision": 2,
+        "createdAt": "2013-09-02T14:56:34.267Z",
+        "updatedAt": "2013-09-02T15:11:24.361Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "fields": {
+        "title": {
+          "en-US": "Nyan Cat"
+        },
+        "file": {
+          "en-US": {
+            "fileName": "Nyan_cat_250px_frame.png",
+            "contentType": "image/png",
+            "details": {
+              "image": {
+                "width": 250,
+                "height": 250
+              },
+              "size": 12273
+            },
+            "url": "//images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png"
+          }
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Asset",
+        "id": "nyancat",
+        "revision": 1,
+        "createdAt": "2013-09-02T14:56:34.240Z",
+        "updatedAt": "2013-09-02T14:56:34.240Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "fields": {
+        "name": {
+          "en-US": "Garfield",
+          "tlh": "Garfield"
+        },
+        "likes": {
+          "en-US": [
+            "lasagna"
+          ]
+        },
+        "color": {
+          "en-US": "orange"
+        },
+        "lifes": {
+          "en-US": null
+        },
+        "lives": {
+          "en-US": 9
+        },
+        "birthday": {
+          "en-US": "1979-06-18T23:00:00+00:00"
+        }
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "cat"
+          }
+        },
+        "id": "garfield",
+        "revision": 2,
+        "createdAt": "2013-06-27T22:46:20.821Z",
+        "updatedAt": "2013-08-27T10:09:07.929Z",
+        "locale": "en-US"
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "cfexampleapi"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "63k4qdEi9aI8IQUGaYGg4O"
+          }
+        },
+        "id": "CVebBDcQsSsu6yKKIayy",
+        "revision": 1,
+        "createdAt": "2013-06-23T19:06:46.224Z",
+        "updatedAt": "2013-06-23T19:06:46.224Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": {
+          "en-US": "Nyancat"
+        }
+      }
+    }
+  ],
+  "nextSyncUrl": "https://cdn.contentful.com/spaces/cfexampleapi/sync?sync_token=bar"
+}


### PR DESCRIPTION
This PR will add rudimentary functionality for requesting a sync in the preview, returning all published and not yet published entries.

Please be advised, that only *initial* synchronisation is supported on the *preview* endpoint. Trying to synchronise with an existing token, will always result in an initial sync on preview.