### PR TITLE
Adding TLS 1.2 configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Version [7.3.1][unreleased] - (in development)
+## Version [7.4.1][unreleased] - (in development)
 - W.I.P. stay tuned...
+
+## Version [7.4.0] - (in development)
+- Added: `useTLS12()` for creating a client enforcing usage of TLS 1.2
 
 ## Version [7.3.0] - (2016-01-04)
 - Added: Fallback locales.
@@ -152,7 +155,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Version 1.0.0 - 2014-08-13
 Initial release.
 
-[unreleased]: https://github.com/contentful/contentful.java/compare/java-sdk-7.3.1...HEAD
+[unreleased]: https://github.com/contentful/contentful.java/compare/java-sdk-7.4.1...HEAD
+[7.4.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.3.0...java-sdk-7.4.0
 [7.3.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.2.0...java-sdk-7.3.0
 [7.2.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.1.0...java-sdk-7.2.0
 [7.1.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.0.2...java-sdk-7.1.0

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Grab via Maven:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>7.3.0</version>
+  <version>7.4.0</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.contentful.java:java-sdk:7.3.0'
+compile 'com.contentful.java:java-sdk:7.4.0'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
@@ -126,7 +126,7 @@ Copyright (c) 2016 Contentful GmbH. See [LICENSE.txt][6] for further details.
 
 
  [1]: https://www.contentful.com
- [2]: https://oss.sonatype.org/service/local/repositories/releases/content/com/contentful/java/java-sdk/7.3.0/java-sdk-7.3.0.jar
+ [2]: https://oss.sonatype.org/service/local/repositories/releases/content/com/contentful/java/java-sdk/7.4.0/java-sdk-7.4.0.jar
  [3]: https://contentful.github.io/contentful.java/
  [4]: https://www.contentful.com/developers/documentation/content-delivery-api/
  [5]: https://square.github.io/okhttp/

--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -92,6 +92,7 @@ public class CDAClient {
           .addInterceptor(new ErrorInterceptor());
 
       okBuilder = setLogger(okBuilder, clientBuilder);
+      okBuilder = useTLS12IfWanted(okBuilder, clientBuilder);
 
       callFactory = okBuilder.build();
     } else {
@@ -116,6 +117,19 @@ public class CDAClient {
         throw new IllegalArgumentException("Cannot log to a null logger. Please set either logLevel to None, or do set a Logger");
       }
     }
+    return okBuilder;
+  }
+
+  private static OkHttpClient.Builder useTLS12IfWanted(OkHttpClient.Builder okBuilder, Builder clientBuilder) {
+
+    if (clientBuilder.useTLS12) {
+      try {
+        okBuilder.sslSocketFactory(new TLSSocketFactory());
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Cannot create TLSSocketFactory for TLS 1.2", e);
+      }
+    }
+
     return okBuilder;
   }
 
@@ -324,6 +338,7 @@ public class CDAClient {
 
     Call.Factory callFactory;
     boolean preview;
+    boolean useTLS12;
 
     /**
      * Sets the space ID.
@@ -380,6 +395,17 @@ public class CDAClient {
      */
     public Builder setCallFactory(Call.Factory callFactory) {
       this.callFactory = callFactory;
+      return this;
+    }
+
+    /**
+     * Sets the flag of enforcing TLS 1.2.
+     * <p>
+     * If this is not used, TLS 1.2 may not be used per default on all
+     * configurations. {@see https://developer.android.com/reference/javax/net/ssl/SSLSocket.html}
+     */
+    public Builder useTLS12() {
+      this.useTLS12 = true;
       return this;
     }
 

--- a/src/main/java/com/contentful/java/cda/TLSSocketFactory.java
+++ b/src/main/java/com/contentful/java/cda/TLSSocketFactory.java
@@ -1,0 +1,71 @@
+package com.contentful.java.cda;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Internal class for enabling TLS 1.2 support on https connections, starting from Android 4.4
+ * <p>
+ * {@see https://developer.android.com/reference/javax/net/ssl/SSLSocket.html}
+ */
+final class TLSSocketFactory extends SSLSocketFactory {
+
+  private static final String[] PROTOCOLS_TLS_1_2_ONLY = {"TLSv1.2"};
+
+  private final SSLSocketFactory delegate;
+
+  TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+    SSLContext context = SSLContext.getInstance("TLS");
+    context.init(null, null, null);
+    delegate = context.getSocketFactory();
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return delegate.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return delegate.getSupportedCipherSuites();
+  }
+
+  @Override
+  public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+    return enableTlsOnSocket(delegate.createSocket(s, host, port, autoClose));
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException {
+    return enableTlsOnSocket(delegate.createSocket(host, port));
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+    return enableTlsOnSocket(delegate.createSocket(host, port, localHost, localPort));
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port) throws IOException {
+    return enableTlsOnSocket(delegate.createSocket(host, port));
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+    return enableTlsOnSocket(delegate.createSocket(address, port, localAddress, localPort));
+  }
+
+  private Socket enableTlsOnSocket(Socket socket) {
+    if (socket != null && (socket instanceof SSLSocket)) {
+      ((SSLSocket) socket).setEnabledProtocols(PROTOCOLS_TLS_1_2_ONLY);
+    }
+    return socket;
+  }
+}

--- a/src/test/java/com/contentful/java/cda/ClientTest.java
+++ b/src/test/java/com/contentful/java/cda/ClientTest.java
@@ -104,7 +104,7 @@ public class ClientTest extends BaseTest {
     } catch (RuntimeException e) {
       assertThat(e.getCause()).isInstanceOf(IOException.class);
       assertThat(e.getCause()).hasMessage(ERROR_MESSAGE);
-      throw(e);
+      throw (e);
     }
   }
 
@@ -208,6 +208,18 @@ public class ClientTest extends BaseTest {
     client.fetch(CDAContentType.class).all();
 
     verify(logMock, times(6)).log(anyString());
+  }
+
+  @Test
+  @Enqueue("demo/content_types_cat.json")
+  public void usingTLS12DoesNotThrow() {
+    final CDAClient client = createBuilder()
+        .useTLS12()
+        .build();
+
+    assertThat(client).isNotNull();
+
+    client.fetch(CDAEntry.class).all();
   }
 
   @Test(expected = CDAHttpException.class)


### PR DESCRIPTION
Please use `.useTLS12()` while creating a `CDAClient` to enforce
using TLS12 on Contentful. This will do the boilerplate code for
you, encouraging you to be as secure as possible.