### PR TITLE
Upgrade Retrofit to 2.2.0 and align it's dependency versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,10 @@
     <java.version>1.6</java.version>
 
     <!-- Dependencies -->
-    <retrofit.version>2.0.1</retrofit.version>
-    <rxjava.version>1.1.2</rxjava.version>
-    <gson.version>2.6.2</gson.version>
-    <okhttp.version>3.2.0</okhttp.version>
+    <retrofit.version>2.2.0</retrofit.version>
+    <rxjava.version>1.2.0</rxjava.version>
+    <gson.version>2.7</gson.version>
+    <okhttp.version>3.6.0</okhttp.version>
 
     <!-- Test Dependencies -->
     <commonsio.version>2.4</commonsio.version>
@@ -117,13 +117,6 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>${okhttp.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp-urlconnection</artifactId>
       <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
We could use the upgrade because of the following:
* The latest version of okhttp has better logging facilities (i.e logging failing connections better, not logging binary content etc)
* Support for JDK9 (in okhttp)

Also removed unused okhttp-urlconnection dependency.