### PR TITLE
enforce enabling TLS 1.2 on Android pre 5.0

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.1.0/apache-maven-3.1.0-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Version [9.0.0] - (2018-01-11)
+- **Remove** `.useTLS12()` from [7.4.0] and replace it with automated approach.
+
 ## Version [8.0.1] - (2017-10-18)
 - Change: Use `filtered` java file to create version number
 - Fix: Gracefully ignore non ascii characters on HTTP header generation.
@@ -195,7 +198,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Version 1.0.0 - 2014-08-13
 Initial release.
 
-[unreleased]: https://github.com/contentful/contentful.java/compare/java-sdk-8.0.1...HEAD
+[unreleased]: https://github.com/contentful/contentful.java/compare/java-sdk-9.0.0...HEAD
+[9.0.0]: https://github.com/contentful/contentful.java/compare/java-sdk-8.0.1...java-sdk-9.0.0
 [8.0.1]: https://github.com/contentful/contentful.java/compare/java-sdk-8.0.0...java-sdk-8.0.1
 [8.0.0]: https://github.com/contentful/contentful.java/compare/java-sdk-7.6.3...java-sdk-8.0.0
 [7.6.2]: https://github.com/contentful/contentful.java/compare/java-sdk-7.6.2...java-sdk-7.6.3

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Grab via Maven:
 <dependency>
   <groupId>com.contentful.java</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>8.0.0</version>
+  <version>9.0.0</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.contentful.java:java-sdk:8.0.0'
+compile 'com.contentful.java:java-sdk:9.0.0'
 ```
 
 The SDK requires at minimum Java 6 or Android 2.3.
@@ -32,14 +32,14 @@ Snapshots of the development version are available through [Sonatype's `snapshot
 
 ```groovy
 maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-compile 'com.contentful.java:java-sdk:8.0.0-SNAPSHOT'
+compile 'com.contentful.java:java-sdk:9.0.0-SNAPSHOT'
 ```
 
 and through [jitpack.io][jitpack]:
 
 ```groovy
 maven { url 'https://jitpack.io' }
-compile 'com.github.contentful:contentful.java:java-sdk-8.0.0-SNAPSHOT'
+compile 'com.github.contentful:contentful.java:java-sdk-9.0.0-SNAPSHOT'
 ```
 
 
@@ -151,7 +151,7 @@ Copyright (c) 2017 Contentful GmbH. See [LICENSE.txt][6] for further details.
 
 
  [1]: https://www.contentful.com
- [2]: https://oss.sonatype.org/service/local/repositories/releases/content/com/contentful/java/java-sdk/7.4.0/java-sdk-7.4.0.jar
+ [2]: https://oss.sonatype.org/service/local/repositories/releases/content/com/contentful/java/java-sdk/9.0.0/java-sdk-9.0.0.jar
  [3]: https://contentful.github.io/contentful.java/
  [4]: https://www.contentful.com/developers/documentation/content-delivery-api/
  [5]: https://square.github.io/okhttp/

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.contentful.java</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>8.0.2-SNAPSHOT</version>
+  <version>9.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/contentful/java/cda/Platform.java
+++ b/src/main/java/com/contentful/java/cda/Platform.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Executor;
  * An platform abstraction layer singleton providing information about the underlying system.
  */
 public abstract class Platform {
-  private static Platform platform = null;
+  static Platform platform = null;
 
   /**
    * @return the current platform.
@@ -47,11 +47,26 @@ public abstract class Platform {
   public abstract String version();
 
   /**
+   * Does this platform need to overwrite the default TLS socket factory to provide TLS1.2
+   * <p>
+   * The servers Contentful uses are enforcing usage of TLS 1.2. Some platforms (Android 4.x) are
+   * having TLS1.2 implemented but are not enabling it as a default. This check finds these
+   * situations and recommends overwriting the default TLSSocketFactory.
+   * <p>
+   * This recommendation can be overruled by using
+   * {@link CDAClient.Builder#setTls12Implementation}.
+   *
+   * @return true if for this platform the custom TLSSocketFactory should be used.
+   */
+  public abstract boolean needsCustomTLSSocketFactory();
+
+  /**
    * @return the platform identified.
    */
   private static Platform findPlatform() {
-    if (tryGettingAndroidSDKNumber() > 0) {
-      return new Android();
+    final int androidVersionNumber = tryGettingAndroidSDKNumber();
+    if (androidVersionNumber > 0) {
+      return new Android(androidVersionNumber, tryGettingAndroidReleaseVersionString());
     } else {
       return new Base();
     }
@@ -60,7 +75,7 @@ public abstract class Platform {
   /**
    * Provides sane defaults for operation on the JVM.
    */
-  private static class Base extends Platform {
+  static class Base extends Platform {
     /**
      * @return a synchronous executor.
      * @see SynchronousExecutor
@@ -82,12 +97,31 @@ public abstract class Platform {
     @Override public String version() {
       return System.getProperty("os.version", "");
     }
+
+    /**
+     * For non Android systems TLS12 should be supported out of the box.
+     *
+     * @return false
+     * @see CDAClient.Builder#setTls12Implementation
+     */
+    @Override public boolean needsCustomTLSSocketFactory() {
+      return false;
+    }
   }
 
   /**
    * Provides sane defaults for operation on Android.
    */
-  private static class Android extends Platform {
+  static class Android extends Platform {
+    private static final int ANDROID_VERSION_FIRST_TO_ENABLE_TLS_12 = 20;
+    private final int versionNumber;
+    private final String versionName;
+
+    Android(int versionNumber, String versionName) {
+      this.versionNumber = versionNumber;
+      this.versionName = versionName;
+    }
+
     /**
      * @return a new executor.
      */
@@ -114,7 +148,22 @@ public abstract class Platform {
      * @return the version number of the android os, if set. Otherwise null.
      */
     @Override public String version() {
-      return tryGettingAndroidReleaseVersionString();
+      return versionName;
+    }
+
+//BEGIN TO LONG CODE LINES
+    /**
+     * Should a custom TLSSocketFactory enable TLS12?
+     * <p>
+     * Overwrite the tlsSocketFactory if the version code is lower then 20,
+     *
+     * @return true if platform supports but doesn't enable TLS12.
+     * @see CDAClient.Builder#setTls12Implementation
+     * @see <a href="https://developer.android.com/reference/javax/net/ssl/SSLSocket.html">Android Documentation</a>
+     */
+//END TO LONG CODE LINES
+    @Override public boolean needsCustomTLSSocketFactory() {
+      return versionNumber < ANDROID_VERSION_FIRST_TO_ENABLE_TLS_12;
     }
   }
 

--- a/src/main/java/com/contentful/java/cda/Tls12Implementation.java
+++ b/src/main/java/com/contentful/java/cda/Tls12Implementation.java
@@ -1,0 +1,21 @@
+package com.contentful.java.cda;
+
+/**
+ * This enumeration stores your choices on how to enable TLS 1.2.
+ */
+public enum Tls12Implementation {
+  /**
+   * Use the SDK recommendation on which Tls12 implementation to use.
+   * @see Platform.Android#needsCustomTLSSocketFactory()
+   * @see Platform.Base#needsCustomTLSSocketFactory()
+   */
+  useRecommendation,
+  /**
+   * Use the system provided TLS socket factory, overriding the recommendation.
+   */
+  systemProvided,
+  /**
+   * The SDK provided TLS socket factory will be used, enabling TLS 1.2 on supported systems.
+   */
+  sdkProvided
+}

--- a/src/main/java/com/contentful/java/cda/TlsSocketFactory.java
+++ b/src/main/java/com/contentful/java/cda/TlsSocketFactory.java
@@ -15,13 +15,13 @@ import javax.net.ssl.SSLSocketFactory;
  * <p>
  * {@see https://developer.android.com/reference/javax/net/ssl/SSLSocket.html}
  */
-final class TLSSocketFactory extends SSLSocketFactory {
+final class TlsSocketFactory extends SSLSocketFactory {
 
   private static final String[] PROTOCOLS_TLS_1_2_ONLY = {"TLSv1.2"};
 
   private final SSLSocketFactory delegate;
 
-  TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+  TlsSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
     SSLContext context = SSLContext.getInstance("TLS");
     context.init(null, null, null);
     delegate = context.getSocketFactory();


### PR DESCRIPTION
Recommend use of a SDK or system provided `TlsSocketFactory`. This recommendation can also be overwritten with using `CDAClient.builder().setTls12Implementation(...)` to enforce usage of either.

This change enables seamless usage on Android systems prior to 20, by overwriting the system provided socket factory.