### PR TITLE
Add 'type' and 'contentType' parameters to CDAService.

### DIFF
--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -298,7 +298,8 @@ public class CDAClient {
     return sync(syncToken, synchronizedSpace, null, null);
   }
 
-  private SyncQuery sync(String syncToken, SynchronizedSpace synchronizedSpace, String type, String contentType) {
+  private SyncQuery sync(String syncToken, SynchronizedSpace synchronizedSpace,
+                         String type, String contentType) {
     if (preview) {
       syncToken = null;
       synchronizedSpace = null;

--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -262,7 +262,11 @@ public class CDAClient {
    */
 
   public SyncQuery sync() {
-    return sync(null, null);
+    return sync(null, (SynchronizedSpace) null);
+  }
+
+  public SyncQuery sync(String type, String contentType) {
+    return sync(null, null, type, contentType);
   }
 
   /**
@@ -275,7 +279,7 @@ public class CDAClient {
    * @return query instance.
    */
   public SyncQuery sync(String syncToken) {
-    return sync(syncToken, null);
+    return sync(syncToken, (SynchronizedSpace) null);
   }
 
   /**
@@ -291,6 +295,10 @@ public class CDAClient {
   }
 
   private SyncQuery sync(String syncToken, SynchronizedSpace synchronizedSpace) {
+    return sync(syncToken, synchronizedSpace, null, null);
+  }
+
+  private SyncQuery sync(String syncToken, SynchronizedSpace synchronizedSpace, String type, String contentType) {
     if (preview) {
       syncToken = null;
       synchronizedSpace = null;
@@ -302,6 +310,12 @@ public class CDAClient {
     }
     if (syncToken != null) {
       builder.setSyncToken(syncToken);
+    }
+    if (type != null) {
+      builder.setType(type);
+    }
+    if (contentType != null) {
+      builder.setContentType(contentType);
     }
     return builder.build();
   }

--- a/src/main/java/com/contentful/java/cda/CDAService.java
+++ b/src/main/java/com/contentful/java/cda/CDAService.java
@@ -30,5 +30,7 @@ interface CDAService {
   Flowable<Response<SynchronizedSpace>> sync(
       @Path("space") String space,
       @Query("initial") Boolean initial,
-      @Query("sync_token") String syncToken);
+      @Query("sync_token") String syncToken,
+      @Query("type") String type,
+      @Query("content_type") String contentType);
 }

--- a/src/main/java/com/contentful/java/cda/ResourceUtils.java
+++ b/src/main/java/com/contentful/java/cda/ResourceUtils.java
@@ -49,7 +49,8 @@ final class ResourceUtils {
     }
 
     Response<SynchronizedSpace> synchronizedSpace =
-        client.service.sync(client.spaceId, null, queryParam(nextPageUrl, "sync_token"))
+        client.service.sync(client.spaceId, null, queryParam(nextPageUrl, "sync_token"),
+            null, null)
             .blockingFirst();
 
     return synchronizedSpace.body();

--- a/src/main/java/com/contentful/java/cda/SyncQuery.java
+++ b/src/main/java/com/contentful/java/cda/SyncQuery.java
@@ -18,11 +18,17 @@ public class SyncQuery {
 
   final boolean initial;
 
+  final String type;
+
+  final String contentType;
+
   private SyncQuery(Builder builder) {
     this.client = checkNotNull(builder.client, "Client must not be null.");
     this.syncToken = builder.syncToken;
     this.space = builder.space;
     this.initial = space == null && syncToken == null;
+    this.type = builder.type;
+    this.contentType = builder.contentType;
   }
 
   /**
@@ -45,7 +51,7 @@ public class SyncQuery {
     return client.cacheAll(true)
         .flatMap(new Function<Cache, Flowable<Response<SynchronizedSpace>>>() {
           @Override public Flowable<Response<SynchronizedSpace>> apply(Cache cache) {
-            return client.service.sync(client.spaceId, initial ? initial : null, token);
+            return client.service.sync(client.spaceId, initial ? initial : null, token, type, contentType);
           }
         }).map(new Function<Response<SynchronizedSpace>, SynchronizedSpace>() {
           @Override public SynchronizedSpace apply(Response<SynchronizedSpace> synchronizedSpace) {
@@ -86,6 +92,10 @@ public class SyncQuery {
 
     SynchronizedSpace space;
 
+    String type;
+
+    String contentType;
+
     Builder setClient(CDAClient client) {
       this.client = client;
       return this;
@@ -98,6 +108,16 @@ public class SyncQuery {
 
     Builder setSpace(SynchronizedSpace space) {
       this.space = space;
+      return this;
+    }
+
+    Builder setType(String type) {
+      this.type = type;
+      return this;
+    }
+
+    Builder setContentType(String contentType) {
+      this.contentType = contentType;
       return this;
     }
 

--- a/src/main/java/com/contentful/java/cda/SyncQuery.java
+++ b/src/main/java/com/contentful/java/cda/SyncQuery.java
@@ -51,7 +51,8 @@ public class SyncQuery {
     return client.cacheAll(true)
         .flatMap(new Function<Cache, Flowable<Response<SynchronizedSpace>>>() {
           @Override public Flowable<Response<SynchronizedSpace>> apply(Cache cache) {
-            return client.service.sync(client.spaceId, initial ? initial : null, token, type, contentType);
+            return client.service.sync(client.spaceId, initial ? initial : null, token,
+                type, contentType);
           }
         }).map(new Function<Response<SynchronizedSpace>, SynchronizedSpace>() {
           @Override public SynchronizedSpace apply(Response<SynchronizedSpace> synchronizedSpace) {

--- a/src/test/java/com/contentful/java/cda/SyncTest.java
+++ b/src/test/java/com/contentful/java/cda/SyncTest.java
@@ -185,4 +185,18 @@ public class SyncTest extends BaseTest {
 
     assertInitial(space);
   }
+
+  @Test
+  public void syncUsesResourceType() throws Exception {
+    final SyncQuery query = client.sync("DeletedEntry", null);
+
+    assertThat("DeletedEntry").isEqualTo(query.type);
+  }
+
+  @Test
+  public void syncUsesContentType() throws Exception {
+    final SyncQuery query = client.sync("Entry", "customType");
+
+    assertThat("customType").isEqualTo(query.contentType);
+  }
 }


### PR DESCRIPTION
Add overloads of CDAClient#sync to accept new parameters.
This would make the SDK fit [the docs](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/synchronization/initial-synchronization-of-entries-of-a-specific-content-type/query-entries/console), and save us from loading unnecessary data.