### PR TITLE
polish: Removed need for synthetic method accessors

### DIFF
--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -67,7 +67,7 @@ public class CDAClient {
 
   final boolean preview;
 
-  private CDAClient(Builder builder) {
+  CDAClient(Builder builder) {
     this(new Cache(),
         Platform.get().callbackExecutor(),
         createService(builder),
@@ -470,7 +470,7 @@ public class CDAClient {
     Section application;
     Section integration;
 
-    private Builder() {
+    Builder() {
     }
 
     /**
@@ -551,7 +551,7 @@ public class CDAClient {
       return this;
     }
 
-    private Call.Factory createOrGetCallFactory(Builder clientBuilder) {
+    Call.Factory createOrGetCallFactory(Builder clientBuilder) {
       final Call.Factory callFactory;
 
       if (clientBuilder.callFactory == null) {

--- a/src/main/java/com/contentful/java/cda/Constants.java
+++ b/src/main/java/com/contentful/java/cda/Constants.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 /**
  * This class holds specific constants, used throughout the sdk, not accessible by mere mortals.
  */
-public class Constants {
+class Constants {
   /**
    * DO NOT CALL THIS CONSTRUCTOR
    *

--- a/src/main/java/com/contentful/java/cda/SyncQuery.java
+++ b/src/main/java/com/contentful/java/cda/SyncQuery.java
@@ -18,7 +18,7 @@ public class SyncQuery {
 
   final boolean initial;
 
-  private SyncQuery(Builder builder) {
+  SyncQuery(Builder builder) {
     this.client = checkNotNull(builder.client, "Client must not be null.");
     this.syncToken = builder.syncToken;
     this.space = builder.space;

--- a/src/main/java/com/contentful/java/cda/interceptor/ContentfulUserAgentHeaderInterceptor.java
+++ b/src/main/java/com/contentful/java/cda/interceptor/ContentfulUserAgentHeaderInterceptor.java
@@ -380,7 +380,7 @@ public class ContentfulUserAgentHeaderInterceptor extends HeaderInterceptor {
     return builder.toString();
   }
 
-  private static String removeNonAsciiCharacters(String input) {
+  static String removeNonAsciiCharacters(String input) {
     final Matcher m = NO_ASCII_PATTERN.matcher(input);
     String result = input;
     if (m.find()) {


### PR DESCRIPTION
* Made `Constants` `package-private` since it's not useful outside of the package.
* Removed all the synthetic method accessors using `package-private`

You can in Intellj at least enabled an inspection for synthetic accessors with `inspections -> J2ME -> Synthetic accessor call`