### PR TITLE
Add error in entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea/
 *.iml
 target/
+.classpath
+.project
+.settings/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-language: java
 sudo: false
+language: java
 
 jdk:
-  - openjdk8
   - oraclejdk8
-  - oraclejdk9
+  - openjdk8
 
 script:
   - mvn jacoco:prepare-agent test jacoco:report

--- a/src/main/java/com/contentful/java/cda/CDAArray.java
+++ b/src/main/java/com/contentful/java/cda/CDAArray.java
@@ -17,6 +17,8 @@ public class CDAArray extends ArrayResource {
 
   Includes includes;
 
+  private List<CDAError> errors;
+
   /**
    * @return total number of resources (linked excluded).
    */
@@ -36,6 +38,17 @@ public class CDAArray extends ArrayResource {
    */
   public int limit() {
     return limit;
+  }
+
+  /**
+   * @return a list of errors if any present
+   */
+  public List<CDAError> getErrors() {
+    return errors;
+  }
+
+  public void setErrors(List<CDAError> errors) {
+    this.errors = errors;
   }
 
   static class Includes {

--- a/src/main/java/com/contentful/java/cda/CDAError.java
+++ b/src/main/java/com/contentful/java/cda/CDAError.java
@@ -1,0 +1,21 @@
+package com.contentful.java.cda;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class CDAError implements Serializable {
+
+  private static final long serialVersionUID = -8417594917359895169L;
+
+  private Map<String, Object> sys;
+
+  private Map<String, Object> details;
+
+  public Map<String, Object> getSys() {
+    return sys;
+  }
+
+  public Map<String, Object> getDetails() {
+    return details;
+  }
+}

--- a/src/main/java/com/contentful/java/cda/ObserveQuery.java
+++ b/src/main/java/com/contentful/java/cda/ObserveQuery.java
@@ -33,42 +33,36 @@ public class ObserveQuery<T extends CDAResource> extends AbsQuery<T, ObserveQuer
    */
   @SuppressWarnings("unchecked")
   public Flowable<T> one(final String id) {
-    Flowable<T> flowable = where("sys.id", id).all().map(
-        new Function<CDAArray, T>() {
-          @Override
-          public T apply(CDAArray array) {
-            if (array.items().size() == 0) {
-              throw new CDAResourceNotFoundException(type, id);
-            }
-            CDAType resourceType = typeForClass(type);
-            if (ASSET.equals(resourceType)) {
-              return (T) array.assets().get(id);
-            } else if (ENTRY.equals(resourceType)) {
-              return (T) array.entries().get(id);
-            } else if (CONTENTTYPE.equals(resourceType)) {
-              return (T) array.items().get(0);
-            } else if (LOCALE.equals(resourceType)) {
-              T found = findById(array, id);
-              if (found == null) {
-                throw new CDAResourceNotFoundException(type, id);
-              }
-              return found;
-            } else {
-              throw new IllegalArgumentException("Cannot invoke query for type: " + type.getName());
-            }
-          }
+    Flowable<T> flowable = where("sys.id", id).all()
+      .map(array -> {
+        if (array.items().size() == 0) {
+          throw new CDAResourceNotFoundException(type, id);
         }
+        CDAType resourceType = typeForClass(type);
+        if (ASSET.equals(resourceType)) {
+          return (T) array.assets().get(id);
+        } else if (ENTRY.equals(resourceType)) {
+          return (T) array.entries().get(id);
+        } else if (CONTENTTYPE.equals(resourceType)) {
+          return (T) array.items().get(0);
+        } else if (LOCALE.equals(resourceType)) {
+          T found = findById(array, id);
+          if (found == null) {
+            throw new CDAResourceNotFoundException(type, id);
+          }
+          return found;
+        } else {
+          throw new IllegalArgumentException("Cannot invoke query for type: " + type.getName());
+        }
+      }
     );
 
     if (CONTENTTYPE.equals(typeForClass(type))) {
-      flowable = flowable.map(new Function<T, T>() {
-        @Override
-        public T apply(T t) {
-          if (t != null) {
-            client.cache.types().put(t.id(), (CDAContentType) t);
-          }
-          return t;
+      flowable = flowable.map(t -> {
+        if (t != null) {
+          client.cache.types().put(t.id(), (CDAContentType) t);
         }
+        return t;
       });
     }
     return flowable;

--- a/src/test/resources/cda/entries_with_errors.json
+++ b/src/test/resources/cda/entries_with_errors.json
@@ -1,0 +1,94 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 2,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "amjnj7ldpank"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "3XN5y2aye44m0Yioko6K6k"
+          }
+        },
+        "id": "3UpazZmO8g8iI0iWAMmGMS",
+        "revision": 1,
+        "createdAt": "2015-07-06T14:55:51.686Z",
+        "updatedAt": "2015-07-06T14:55:51.686Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "link": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Entry",
+            "id": "1y5CUd7lwMQaI2micsAWIO"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "amjnj7ldpank"
+          }
+        },
+        "type": "Entry",
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "3lYaFZKDgQCUwWy6uEoQYi"
+          }
+        },
+        "id": "1y5CUd7lwMQaI2micsAWIO",
+        "revision": 2,
+        "createdAt": "2015-07-06T14:55:41.548Z",
+        "updatedAt": "2015-07-07T12:37:23.236Z",
+        "locale": "en-US"
+      },
+      "fields": {
+        "name": "bar"
+      }
+    }
+  ],
+  "errors": [
+    {
+      "sys": {
+        "id": "notResolvable",
+        "type": "error"
+      },
+      "details": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "3UpazZmO8g8iI0iWAMmGMS"
+      }
+    },
+    {
+      "sys": {
+        "id": "notResolvable",
+        "type": "error"
+      },
+      "details": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "1y5CUd7lwMQaI2micsAWIO"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- In some cases, entries can include an error object when an entry's reference doesn't exist. With this PR, users can obtain the error content. 
- Remove `oraclejdk9`. This is no longer supported in Travis https://travis-ci.community/t/oraclejdk9-broken/3484