### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: java
 
+dist: bionic
+
 jdk:
   - oraclejdk8
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 
-dist: bionic
+dist: trusty
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Add `dist: trusty` to travis configuration, because default distro doesn't support `oraclejdk8`. 
See more https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766