### PR TITLE
Add support for named capture groups on Android API < 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.tony19</groupId>
+      <artifactId>named-regexp</artifactId>
+      <version>0.2.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/contentful/java/cda/TransformQuery.java
+++ b/src/main/java/com/contentful/java/cda/TransformQuery.java
@@ -1,5 +1,7 @@
 package com.contentful.java.cda;
 
+import com.google.code.regexp.Matcher;
+import com.google.code.regexp.Pattern;
 import io.reactivex.Flowable;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
@@ -14,8 +16,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * This query will tranform an incoming contentful entry to a custom type.


### PR DESCRIPTION
This PR should resolve issue https://github.com/contentful/contentful.java/issues/204

Problem was with the 
`return this.getClass().getClassLoader().loadClass(matcher.group("subtype"));` code.
As `.group(String group)` method is available only from API 26.
I replaced it with the library that supports Java 5/6 in that matter: https://github.com/tony19/named-regexp