### PR TITLE
feat: use a shared connection pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <retrofit.version>2.5.0</retrofit.version>
     <rxjava.version>2.2.6</rxjava.version>
     <gson.version>2.8.5</gson.version>
-    <okhttp.version>3.12.1</okhttp.version>
+    <okhttp.version>3.12.12</okhttp.version>
 
     <!-- Test Dependencies -->
     <commonsio.version>2.6</commonsio.version>

--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -535,6 +535,8 @@ public class CDAClient {
     Section application;
     Section integration;
 
+    private static final OkHttpClient OK_HTTP_CLIENT = new OkHttpClient();
+
     Builder() {
     }
 
@@ -725,7 +727,9 @@ public class CDAClient {
      */
     public OkHttpClient.Builder defaultCallFactoryBuilder() {
       final Section[] sections = createCustomHeaderSections(application, integration);
+
       OkHttpClient.Builder okBuilder = new OkHttpClient.Builder()
+          .connectionPool(OK_HTTP_CLIENT.connectionPool())
           .addInterceptor(new AuthorizationHeaderInterceptor(token))
           .addInterceptor(new UserAgentHeaderInterceptor(createUserAgent()))
           .addInterceptor(new ContentfulUserAgentHeaderInterceptor(sections))


### PR DESCRIPTION
When rapidly creating new CDAClient instances multiple connection pools are created, each with connections open. This eventually causes SSL handshakes to fail and a quick increase of memory usage.

Prevent this by using a shared connection pool.

I was thinking to clone the Builder, but that seems discouraged https://github.com/square/okhttp/issues/4168, so I went with only sharing the connection pool itself.

I also updated okhttp while we are at it https://square.github.io/okhttp/changelog_3x/#version-31212 as it has various fixes. If I understand correctly we can't upgrade to 3.13+ as this changes the minimum requirements to Java 8+ or Android 5+.