### PR TITLE
Dont add all jackson modules on the classpath

### DIFF
--- a/src/main/java/com/contentful/java/cda/ResourceFactory.java
+++ b/src/main/java/com/contentful/java/cda/ResourceFactory.java
@@ -121,7 +121,6 @@ final class ResourceFactory {
         .addModule(new Jdk8Module())
         .addModule(new JavaTimeModule())
         .addModule(new MrBeanModule())
-        .findAndAddModules()
         .enable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
         .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)


### PR DESCRIPTION
We've experienced problems with the Contentful SDK where it would fail to deserialize java classes through Jackson as expected on Java versions above 11.

```
Sep 10, 2021 4:12:20 PM com.fasterxml.jackson.module.afterburner.deser.OptimizedSettableBeanProperty _reportProblem
WARNING: Disabling Afterburner deserialization for class com.contentful.java.cda.CDAArray (field #2; mutator com.fasterxml.jackson.module.afterburner.deser.SettableObjectFieldProperty), due to access error (type java.lang.IllegalAccessError, message=class com.contentful.java.cda.CDAArray$Access4JacksonDeserializerf7be59e7 tried to access field com.contentful.java.cda.CDAResource.attrs (com.contentful.java.cda.CDAArray$Access4JacksonDeserializerf7be59e7 is in unnamed module of loader com.fasterxml.jackson.module.afterburner.util.MyClassLoader @3592a28e; com.contentful.java.cda.CDAResource is in unnamed module of loader 'app'))

java.lang.IllegalAccessError: class com.contentful.java.cda.CDAArray$Access4JacksonDeserializerf7be59e7 tried to access field com.contentful.java.cda.CDAResource.attrs (com.contentful.java.cda.CDAArray$Access4JacksonDeserializerf7be59e7 is in unnamed module of loader com.fasterxml.jackson.module.afterburner.util.MyClassLoader @3592a28e; com.contentful.java.cda.CDAResource is in unnamed module of loader 'app')
```

After a bit of digging the problem is related to reflections in the Jackson module Afterburner no longer allowed in Java versions above 11.

But I could not find any referenses to Aftrerburner in contentful, I did however see that you add *all* Jackson modules on the classpath to the ObjectMapper used. This is a problem for us, and might be for others, since Afterburner is on our classpath but not used, since its a transitive dependency.

I believe the right solution here is _not_ for contentfuls ObjectMapper to go ahead and register all Jackson modules on the classpath, but instead just register the ones it needs.