### PR TITLE
Upgrade to RxJava3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     <java.version>1.8</java.version>
 
     <!-- Dependencies -->
-    <retrofit.version>2.5.0</retrofit.version>
-    <rxjava.version>2.2.6</rxjava.version>
+    <retrofit.version>2.9.0</retrofit.version>
+    <rxjava.version>3.1.3</rxjava.version>
     <gson.version>2.8.5</gson.version>
     <okhttp.version>3.12.12</okhttp.version>
 
@@ -81,7 +81,7 @@
 
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
-      <artifactId>adapter-rxjava2</artifactId>
+      <artifactId>adapter-rxjava3</artifactId>
       <version>${retrofit.version}</version>
     </dependency>
 
@@ -92,7 +92,7 @@
     </dependency>
 
     <dependency>
-      <groupId>io.reactivex.rxjava2</groupId>
+      <groupId>io.reactivex.rxjava3</groupId>
       <artifactId>rxjava</artifactId>
       <version>${rxjava.version}</version>
     </dependency>

--- a/src/main/java/com/contentful/java/cda/CDACallback.java
+++ b/src/main/java/com/contentful/java/cda/CDACallback.java
@@ -1,6 +1,6 @@
 package com.contentful.java.cda;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /**
  * Communicates responses from a server or offline requests. One and only one method will be

--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -10,14 +10,14 @@ import com.contentful.java.cda.interceptor.ContentfulUserAgentHeaderInterceptor.
 import com.contentful.java.cda.interceptor.ErrorInterceptor;
 import com.contentful.java.cda.interceptor.LogInterceptor;
 import com.contentful.java.cda.interceptor.UserAgentHeaderInterceptor;
-import io.reactivex.Flowable;
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Function;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import org.reactivestreams.Publisher;
 import retrofit2.Response;
 import retrofit2.Retrofit;
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 import javax.net.ssl.TrustManager;
@@ -107,7 +107,7 @@ public class CDAClient {
 
     Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
         .addConverterFactory(GsonConverterFactory.create(ResourceFactory.GSON))
-        .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
         .callFactory(clientBuilder.createOrGetCallFactory(clientBuilder))
         .baseUrl(endpoint);
 

--- a/src/main/java/com/contentful/java/cda/CDAService.java
+++ b/src/main/java/com/contentful/java/cda/CDAService.java
@@ -1,6 +1,6 @@
 package com.contentful.java.cda;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 import retrofit2.Response;
 import retrofit2.http.GET;
 import retrofit2.http.Path;

--- a/src/main/java/com/contentful/java/cda/Callbacks.java
+++ b/src/main/java/com/contentful/java/cda/Callbacks.java
@@ -1,9 +1,9 @@
 package com.contentful.java.cda;
 
-import io.reactivex.Flowable;
-import io.reactivex.flowables.ConnectableFlowable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.flowables.ConnectableFlowable;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 final class Callbacks {
   private Callbacks() {
@@ -11,7 +11,7 @@ final class Callbacks {
   }
 
   static <O, C> CDACallback<C> subscribeAsync(
-      Flowable<O> flowable, CDACallback<C> callback, CDAClient client) {
+          Flowable<O> flowable, CDACallback<C> callback, CDAClient client) {
     ConnectableFlowable<O> connectable = flowable.observeOn(Schedulers.io()).publish();
 
     callback.setSubscription(connectable.subscribe(

--- a/src/main/java/com/contentful/java/cda/ObserveQuery.java
+++ b/src/main/java/com/contentful/java/cda/ObserveQuery.java
@@ -1,7 +1,7 @@
 package com.contentful.java.cda;
 
-import io.reactivex.Flowable;
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Function;
 import org.reactivestreams.Publisher;
 import retrofit2.Response;
 

--- a/src/main/java/com/contentful/java/cda/ResourceUtils.java
+++ b/src/main/java/com/contentful/java/cda/ResourceUtils.java
@@ -1,8 +1,8 @@
 package com.contentful.java.cda;
 
-import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.functions.Predicate;
 import retrofit2.Response;
 
 import java.util.ArrayList;

--- a/src/main/java/com/contentful/java/cda/SyncQuery.java
+++ b/src/main/java/com/contentful/java/cda/SyncQuery.java
@@ -1,7 +1,7 @@
 package com.contentful.java.cda;
 
-import io.reactivex.Flowable;
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Function;
 import org.reactivestreams.Publisher;
 import retrofit2.Response;
 

--- a/src/main/java/com/contentful/java/cda/TransformQuery.java
+++ b/src/main/java/com/contentful/java/cda/TransformQuery.java
@@ -2,9 +2,9 @@ package com.contentful.java.cda;
 
 import com.google.code.regexp.Matcher;
 import com.google.code.regexp.Pattern;
-import io.reactivex.Flowable;
-import io.reactivex.functions.Function;
-import io.reactivex.functions.Predicate;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.functions.Predicate;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;


### PR DESCRIPTION
Per [RxJava](https://github.com/ReactiveX/RxJava):

"The [2.x version](https://github.com/ReactiveX/RxJava/tree/2.x) is end-of-life as of February 28, 2021. No further development, support, maintenance, PRs and updates will happen."

This PR migrates from version 2.x to 3.x, ensuring the contenful Java SDK is using a supported version of RxJava.