### PR TITLE
Changed RxJava version to avoid conflict with Retrofit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <!-- Dependencies -->
     <retrofit.version>2.9.0</retrofit.version>
-    <rxjava.version>3.1.3</rxjava.version>
+    <rxjava.version>3.0.0</rxjava.version>
     <gson.version>2.8.5</gson.version>
     <okhttp.version>3.12.12</okhttp.version>
 


### PR DESCRIPTION
## Downgrade of RxJava from version 3.1.3 to 3.0.0 to avoid dependency conflict with Retrofit version 2.9.0

- Why is it a problem?
  - The root pom defines <b>RxJava in version 3.1.3</b> and the dependency towards <b>Retrofit2 transitively uses RxJava in version 3.0.0</b>. Although RxJava 3.0.0 is shadowed at compile time, there are methods with different signatures called which would potentially lead to a <b>runtime error</b>. One example of the reported conflicts:
<i>rxjava/3.0.0 CLASHES WITH rxjava/3.1.3
CLASS: io.reactivex.rxjava3.internal.schedulers.ScheduledDirectPeriodicTask
METHOD: <init>, PARAMETER COUNTS: 1 AND 2, RETURN TYPES: void AND void</i>

- Why did we analyze contentful.java?
   - As a part of the Master Program in Informatics, I am analyzing dependency conflicts in Java projects. For the evaluation, I analyzed over 800 open-source Java projects on Github. Contentful.java was one of the analyzed projects.

 <h2>Example of two conflicting call paths in reverse call order (conflicting method to the first method within contentful.java):</h2>

<b>TRACE TO REACH FIRST CLASHING ARGUMENTS OF CLASH:  
~/io.reactivex.rxjava3/rxjava/3.0.0 CLASHES WITH ~/io.reactivex.rxjava3/rxjava/3.1.3 --> 
CLASS: io.reactivex.rxjava3.internal.schedulers.ScheduledDirectPeriodicTask 
METHOD: `<init>` 
PARAMETER COUNS: 1 
RETURN TYPE: void  </b>

==> CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler:schedulePeriodicallyDirect(4)) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.schedulers.ScheduledDirectPeriodicTask:<init>(1))

==> CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Scheduler:schedulePeriodicallyDirect(4)) -->
 CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler:schedulePeriodicallyDirect(4))

==> CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.operators.flowable.FlowableIntervalRange:subscribeActual(1)) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Scheduler:schedulePeriodicallyDirect(4))

==> CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribeActual(1)) -->
 CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.operators.flowable.FlowableIntervalRange:subscribeActual(1))

==> CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribe(1)) -->
 CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribeActual(1))

==> CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:blockingFirst()) -->
 CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribe(1))

==> ROOT_TRACE - 
CALLER: (java-sdk-10.5.3-SNAPSHOT.jar, com.contentful.java.cda.ResourceUtils:ensureContentType(2)) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:blockingFirst())


<b>TRACE TO REACH SECOND CLASHING ARGUMENTS OF CLASH: 
~/io.reactivex.rxjava3/rxjava/3.0.0 CLASHES WITH ~/io.reactivex.rxjava3/rxjava/3.1.3 --> 
CLASS: io.reactivex.rxjava3.internal.schedulers.ScheduledDirectPeriodicTask 
METHOD: `<init> `
PARAMETER COUNTS:  2 
RETURN TYPES:  void  </b>

==>CALLER: (rxjava-3.1.3.jar, io.reactivex.rxjava3.internal.schedulers.SingleScheduler:schedulePeriodicallyDirect(4)) --> 
CALLEE: (rxjava-3.1.3.jar, io.reactivex.rxjava3.internal.schedulers.ScheduledDirectPeriodicTask:<init>(2))

==>CALLER: (rxjava-3.1.3.jar, io.reactivex.rxjava3.core.Scheduler:schedulePeriodicallyDirect(4)) --> 
CALLEE: (rxjava-3.1.3.jar, io.reactivex.rxjava3.internal.schedulers.SingleScheduler:schedulePeriodicallyDirect(4))

==>CALLER: (rxjava-3.1.3.jar, io.reactivex.rxjava3.internal.operators.flowable.FlowableSampleTimed$SampleTimedSubscriber:onSubscribe(1)) -->
 CALLEE: (rxjava-3.1.3.jar, io.reactivex.rxjava3.core.Scheduler:schedulePeriodicallyDirect(4))

==>CALLER: (rxjava-3.1.3.jar, io.reactivex.rxjava3.core.FlowableSubscriber:onSubscribe(1)) -->
 CALLEE: (rxjava-3.1.3.jar, io.reactivex.rxjava3.internal.operators.flowable.FlowableSampleTimed$SampleTimedSubscriber:onSubscribe(1))

==>CALLER: (reactive-streams-1.0.3.jar, org.reactivestreams.Subscriber:onSubscribe(1)) --> 
CALLEE: (rxjava-3.1.3.jar, io.reactivex.rxjava3.core.FlowableSubscriber:onSubscribe(1))

==>CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.operators.flowable.FlowableIntervalRange:subscribeActual(1)) --> 
CALLEE: (reactive-streams-1.0.3.jar, org.reactivestreams.Subscriber:onSubscribe(1))

==>CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribeActual(1)) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.internal.operators.flowable.FlowableIntervalRange:subscribeActual(1))

==>CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribe(1)) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribeActual(1))

==>CALLER: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:blockingFirst()) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:subscribe(1))

==>ROOT_TRACE - 
CALLER: (java-sdk-10.5.3-SNAPSHOT.jar, com.contentful.java.cda.ResourceUtils:ensureContentType(2)) --> 
CALLEE: (rxjava-3.0.0.jar, io.reactivex.rxjava3.core.Flowable:blockingFirst())
