### PR TITLE
fix: add type property for rich mark classes besides custom mark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.contentful.java</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>10.5.8-SNAPSHOT</version>
+  <version>10.5.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/contentful/java/cda/rich/CDARichMark.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichMark.java
@@ -6,50 +6,75 @@ package com.contentful.java.cda.rich;
  * Subclasses are used for further differentiation.
  */
 public class CDARichMark {
+
+  public CDARichMark(String type) {
+    this.type = type;
+  }
+
+  /**
+   * @return the type of the marker.
+   */
+  public String getType() {
+    return type;
+  }
+
+  protected final String type;
+
   /**
    * A bold mark of a rich text.
    */
   public static class CDARichMarkBold extends CDARichMark {
+
+    public CDARichMarkBold() {
+      super("bold");
+    }
+
   }
 
   /**
    * Declares the text as being displayed in italics.
    */
   public static class CDARichMarkItalic extends CDARichMark {
+
+    public CDARichMarkItalic() {
+      super("italic");
+    }
+
   }
 
   /**
    * Marker for making the rich text displayed as underline.
    */
   public static class CDARichMarkUnderline extends CDARichMark {
+
+    public CDARichMarkUnderline() {
+      super("underline");
+    }
+
   }
 
   /**
    * The text marked by this marker should be represented by Code.
    */
   public static class CDARichMarkCode extends CDARichMark {
+
+    public CDARichMarkCode() {
+      super("code");
+    }
+
   }
 
   /**
    * Any custom marker for a given rich text.
    */
   public static class CDARichMarkCustom extends CDARichMark {
-    private final String type;
-
     /**
      * Create a custom marker using the given type.
      *
      * @param type which type should this marker have?
      */
     public CDARichMarkCustom(String type) {
-      this.type = type;
-    }
-
-    /**
-     * @return the custom type of the marker.
-     */
-    public String getType() {
-      return type;
+      super(type);
     }
   }
 }


### PR DESCRIPTION
This PR should resolve the [issue](https://github.com/contentful/contentful.java/issues/268) that I have encountered. I have tested this using another project by importing the packaged JAR into `pom.xml`. 

Let me know if I should add some tests to this use case but I had to skip tests as I was not able to package the JAR. 