### PR TITLE
Add toString method for queries, so that they can be logged

### DIFF
--- a/src/main/java/com/contentful/java/cda/AbsQuery.java
+++ b/src/main/java/com/contentful/java/cda/AbsQuery.java
@@ -487,4 +487,9 @@ public abstract class AbsQuery<
     }
     return count;
   }
+
+  @Override
+  public String toString() {
+    return "AbsQuery{type=" + type + ", params=" + params + '}';
+  }
 }

--- a/src/test/java/com/contentful/java/cda/AbsQueryTest.java
+++ b/src/test/java/com/contentful/java/cda/AbsQueryTest.java
@@ -613,4 +613,24 @@ public class AbsQueryTest {
     final FetchQuery<CDAContentType> typeQuery = new FetchQuery<>(CDAContentType.class, client);
     typeQuery.where("name", Matches, "Auth");
   }
+
+  @Test
+  public void string() {
+    String string = query
+      .withContentType("foo")
+      .withLocale("en")
+      .where("fields.value", IsLessThanOrEqualTo, 10)
+      .include(2)
+      .skip(5)
+      .orderBy("baz")
+      .toString();
+
+    assertThat(string).contains("type=class com.contentful.java.cda.CDAResource");
+    assertThat(string).contains("content_type=foo");
+    assertThat(string).contains("locale=en");
+    assertThat(string).contains("fields.value[lte]=10");
+    assertThat(string).contains("include=2");
+    assertThat(string).contains("skip=5");
+    assertThat(string).contains("order=baz");
+  }
 }


### PR DESCRIPTION
In case a query returns errors (such as ["not resolvable" items](https://www.contentful.com/faq/apis/#why-do-i-see-error-not-resolvable-in-api-response), I would like to be able to log the query details along with the errors details, so that I have everything I need to fix things.