### PR TITLE
feature: Add param for logging sensitive auth headers in CDAHttpException class.

### DIFF
--- a/src/main/java/com/contentful/java/cda/CDAClient.java
+++ b/src/main/java/com/contentful/java/cda/CDAClient.java
@@ -73,6 +73,8 @@ public class CDAClient {
 
   final boolean preview;
 
+  final boolean logSensitiveData;
+
   CDAClient(Builder builder) {
     this(new Cache(),
         Platform.get().callbackExecutor(),
@@ -89,6 +91,7 @@ public class CDAClient {
     this.environmentId = builder.environment;
     this.token = builder.token;
     this.preview = builder.preview;
+    this.logSensitiveData = builder.logSensitiveData;
   }
 
   private void validate(Builder builder) {
@@ -306,6 +309,10 @@ public class CDAClient {
     return sync(null, null, type);
   }
 
+
+  public boolean shouldLogSensitiveData() {
+    return logSensitiveData;
+  }
   /**
    * Returns a {@link SyncQuery} for synchronization with the provided {@code syncToken} via
    * the Sync API.
@@ -532,6 +539,8 @@ public class CDAClient {
     Converter.Factory converterFactory;
 
     boolean preview;
+
+    private boolean logSensitiveData = true;
     Tls12Implementation tls12Implementation = useRecommendation;
 
     Section application;
@@ -561,6 +570,18 @@ public class CDAClient {
      */
     public Builder setEnvironment(String environment) {
       this.environment = environment;
+      return this;
+    }
+
+    /**
+     * Sets the logSensitiveData value for logging
+     * the authorization headers in the CDAHttpException.
+     *
+     * @param logSensitiveData boolean value to be set.
+     * @return this builder for chaining.
+     */
+    public Builder setLogSensitiveData(boolean logSensitiveData) {
+      this.logSensitiveData = logSensitiveData;
       return this;
     }
 
@@ -758,7 +779,7 @@ public class CDAClient {
           .addInterceptor(new AuthorizationHeaderInterceptor(token))
           .addInterceptor(new UserAgentHeaderInterceptor(createUserAgent()))
           .addInterceptor(new ContentfulUserAgentHeaderInterceptor(sections))
-          .addInterceptor(new ErrorInterceptor());
+          .addInterceptor(new ErrorInterceptor(logSensitiveData));
 
       setLogger(okBuilder);
       useTls12IfWanted(okBuilder);

--- a/src/main/java/com/contentful/java/cda/CDAHttpException.java
+++ b/src/main/java/com/contentful/java/cda/CDAHttpException.java
@@ -22,6 +22,8 @@ public class CDAHttpException extends RuntimeException {
   private final String responseBody;
   private final String stringRepresentation;
 
+  private final boolean logSensitiveData;
+
   /**
    * Construct an error response.
    * <p>
@@ -32,12 +34,13 @@ public class CDAHttpException extends RuntimeException {
    * @param request  the request issuing the error.
    * @param response the response from the server to this faulty request.
    */
-  public CDAHttpException(Request request, Response response) {
+  public CDAHttpException(Request request, Response response, boolean logSensitiveData) {
     super(response.message());
     this.request = request;
     this.response = response;
     this.responseBody = readResponseBody(response);
     this.stringRepresentation = createString();
+    this.logSensitiveData = logSensitiveData;
   }
 
   private String readResponseBody(Response response) {
@@ -133,6 +136,10 @@ public class CDAHttpException extends RuntimeException {
   }
 
   private String headersToString(Headers headers) {
+    if (!logSensitiveData) {
+      return "<headers omitted>";
+    }
+
     final StringBuilder builder = new StringBuilder();
 
     String divider = "";

--- a/src/main/java/com/contentful/java/cda/interceptor/ErrorInterceptor.java
+++ b/src/main/java/com/contentful/java/cda/interceptor/ErrorInterceptor.java
@@ -12,6 +12,12 @@ import okhttp3.Response;
  * This interceptor will only be used for throwing an exception, once the server returns an error.
  */
 public class ErrorInterceptor implements Interceptor {
+  private final boolean logSensitiveData;
+
+  public ErrorInterceptor(boolean logSensitiveData) {
+    this.logSensitiveData = logSensitiveData;
+  }
+
 
   /**
    * Intercepts chain to check for unsuccessful requests.
@@ -25,7 +31,7 @@ public class ErrorInterceptor implements Interceptor {
     final Response response = chain.proceed(request);
 
     if (!response.isSuccessful()) {
-      throw new CDAHttpException(request, response);
+      throw new CDAHttpException(request, response, logSensitiveData);
     }
 
     return response;


### PR DESCRIPTION
As per request in https://github.com/contentful/contentful.java/issues/293 This adds the `logSensitiveData`  field for configuring whetear the `CDAHttpException` should log auth headers or not. The example usage would be:

`CDAClient client = new CDAClient.Builder()
    .setAccessToken("your_access_token")
    .setSpace("your_space_id")
    .setLogSensitiveData(false)
    .build();`