### PR TITLE
Remove dependency on named-regexp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,6 @@
       <artifactId>gson</artifactId>
       <version>${gson.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.github.tony19</groupId>
-      <artifactId>named-regexp</artifactId>
-      <version>0.2.5</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/contentful/java/cda/TransformQuery.java
+++ b/src/main/java/com/contentful/java/cda/TransformQuery.java
@@ -1,7 +1,5 @@
 package com.contentful.java.cda;
 
-import com.google.code.regexp.Matcher;
-import com.google.code.regexp.Pattern;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.functions.Predicate;
@@ -16,6 +14,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This query will tranform an incoming contentful entry to a custom type.


### PR DESCRIPTION
named-regexp is a backport of named capture groups, which were introduced in Java 7. This library targets Java 8, so the backport is unnecessary.

See https://github.com/tony19/named-regexp/issues/73#issuecomment-1897810289