### PR TITLE
feat: Implement Serializable interface for rich text classes

### DIFF
--- a/src/main/java/com/contentful/java/cda/rich/CDARichBlock.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichBlock.java
@@ -1,12 +1,13 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
 /**
  * A collection of several nodes.
  */
-public class CDARichBlock extends CDARichNode {
+public class CDARichBlock extends CDARichNode implements Serializable {
   final List<CDARichNode> content = new LinkedList<>();
 
   /**

--- a/src/main/java/com/contentful/java/cda/rich/CDARichDocument.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichDocument.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * The base of a rich text field, containing all the other nodes.
  */
-public class CDARichDocument extends CDARichBlock {
+public class CDARichDocument extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichEmbeddedBlock.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichEmbeddedBlock.java
@@ -1,11 +1,13 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * This node is an inline link to a CDAEntry
  *
  * @see com.contentful.java.cda.CDAEntry
  */
-public class CDARichEmbeddedBlock extends CDARichHyperLink {
+public class CDARichEmbeddedBlock extends CDARichHyperLink implements Serializable {
   /**
    * Create a link pointing to a CDAEntry.
    *

--- a/src/main/java/com/contentful/java/cda/rich/CDARichEmbeddedInline.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichEmbeddedInline.java
@@ -1,11 +1,13 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * This node is an inline link to a CDAEntry
  *
  * @see com.contentful.java.cda.CDAEntry
  */
-public class CDARichEmbeddedInline extends CDARichHyperLink {
+public class CDARichEmbeddedInline extends CDARichHyperLink implements Serializable {
   /**
    * Create a link pointing to a CDAEntry.
    *

--- a/src/main/java/com/contentful/java/cda/rich/CDARichHeading.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichHeading.java
@@ -1,11 +1,13 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * Defines a headline of the text.
  * <p>
  * Can have an arbitrary level assigned, but useful probably between 1 and 6.
  */
-public class CDARichHeading extends CDARichBlock {
+public class CDARichHeading extends CDARichBlock implements Serializable {
   private final int level;
 
   /**

--- a/src/main/java/com/contentful/java/cda/rich/CDARichHorizontalRule.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichHorizontalRule.java
@@ -1,9 +1,11 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A node representing a division, called a horizontal rule.
  */
-public class CDARichHorizontalRule extends CDARichNode {
+public class CDARichHorizontalRule extends CDARichNode implements Serializable {
   /**
    * Construct this node.
    */

--- a/src/main/java/com/contentful/java/cda/rich/CDARichHyperLink.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichHyperLink.java
@@ -1,9 +1,11 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * This block represents a link to a website.
  */
-public class CDARichHyperLink extends CDARichBlock {
+public class CDARichHyperLink extends CDARichBlock implements Serializable {
   Object data;
 
   /**

--- a/src/main/java/com/contentful/java/cda/rich/CDARichList.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichList.java
@@ -1,9 +1,11 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * Parent class for all list classes
  */
-public class CDARichList extends CDARichBlock {
+public class CDARichList extends CDARichBlock implements Serializable {
   final CharSequence decoration;
 
   /**

--- a/src/main/java/com/contentful/java/cda/rich/CDARichListItem.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichListItem.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A block representing an item inside a list.
  */
-public class CDARichListItem extends  CDARichBlock {
+public class CDARichListItem extends  CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichMark.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichMark.java
@@ -1,11 +1,13 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * How to draw a given text.
  * <p>
  * Subclasses are used for further differentiation.
  */
-public class CDARichMark {
+public class CDARichMark implements Serializable {
 
   public CDARichMark(String type) {
     this.type = type;

--- a/src/main/java/com/contentful/java/cda/rich/CDARichNode.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichNode.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A leaf node of the rich text hierarchy.
  */
-public class CDARichNode {
+public class CDARichNode implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichOrderedList.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichOrderedList.java
@@ -1,9 +1,11 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A list of elements, ordered by number.
  */
-public class CDARichOrderedList extends CDARichList {
+public class CDARichOrderedList extends CDARichList implements Serializable {
   /**
    * Create a list with numbers.
    */

--- a/src/main/java/com/contentful/java/cda/rich/CDARichParagraph.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichParagraph.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A paragraph of nodes, usually rendered together.
  */
-public class CDARichParagraph extends CDARichBlock {
+public class CDARichParagraph extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichQuote.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichQuote.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A block of nodes rendered as a direct quote.
  */
-public class CDARichQuote extends CDARichBlock {
+public class CDARichQuote extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichTable.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichTable.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A paragraph of nodes, usually rendered together.
  */
-public class CDARichTable extends CDARichBlock {
+public class CDARichTable extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichTableCell.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichTableCell.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A paragraph of nodes, usually rendered together.
  */
-public class CDARichTableCell extends CDARichBlock {
+public class CDARichTableCell extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichTableHeaderCell.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichTableHeaderCell.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A paragraph of nodes, usually rendered together.
  */
-public class CDARichTableHeaderCell extends CDARichBlock {
+public class CDARichTableHeaderCell extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichTableRow.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichTableRow.java
@@ -1,7 +1,9 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * A paragraph of nodes, usually rendered together.
  */
-public class CDARichTableRow extends CDARichBlock {
+public class CDARichTableRow extends CDARichBlock implements Serializable {
 }

--- a/src/main/java/com/contentful/java/cda/rich/CDARichText.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichText.java
@@ -1,12 +1,13 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * A leaf element of the rich text node graph: Render a given text with the given markings.
  */
-public class CDARichText extends CDARichNode {
+public class CDARichText extends CDARichNode implements Serializable {
   private final List<CDARichMark> marks = new ArrayList<>();
   private final CharSequence text;
 

--- a/src/main/java/com/contentful/java/cda/rich/CDARichUnorderedList.java
+++ b/src/main/java/com/contentful/java/cda/rich/CDARichUnorderedList.java
@@ -1,9 +1,11 @@
 package com.contentful.java.cda.rich;
 
+import java.io.Serializable;
+
 /**
  * Representation of a block of unordered items.
  */
-public class CDARichUnorderedList extends CDARichList {
+public class CDARichUnorderedList extends CDARichList implements Serializable {
   /**
    * Create a list with bullet points.
    */


### PR DESCRIPTION
I propose adding the Serializable interface for CDARich items so that when consuming the library I can cache and use other tools requiring direct Java serialization/deserialization of these objects.  Gitbutler AI generated the below message for the commit message.

The changes in this commit add the Serializable interface to various classes in the `com.contentful.java.cda.rich` package. This allows these classes to be easily serialized and deserialized, which is important for use cases where the rich text data needs to be persisted or transmitted over a network.

The main classes that now implement Serializable are:

- `CDARichTableCell`
- `CDARichQuote`
- `CDARichListItem`
- `CDARichTableRow`
- `CDARichTable`
- `CDARichText`
- `CDARichNode`
- `CDARichMark`
- `CDARichHorizontalRule`
- `CDARichList`
- `CDARichUnorderedList`
- `CDARichEmbeddedInline`
- `CDARichHyperLink`

This change will enable better integration with other systems and frameworks that require serializable data and will improve the overall flexibility and usability of the rich text handling functionality in the Contentful Java CDA SDK.