### PR TITLE
Gracefully handle unknown fields

### DIFF
--- a/src/main/java/com/contentful/java/cda/TransformQuery.java
+++ b/src/main/java/com/contentful/java/cda/TransformQuery.java
@@ -465,7 +465,8 @@ public class TransformQuery<Transformed>
           // Field doesn't exist on the result object, skip it and continue
         }
       } else if (value instanceof Collection) {
-        @SuppressWarnings("unchecked") final Collection<Object> collection = (Collection<Object>) value;
+        @SuppressWarnings("unchecked") final Collection<Object> collection
+                = (Collection<Object>) value;
 
         final ArrayList<Object> transformedList = new ArrayList<>(collection.size());
         for (final Object element : collection) {
@@ -480,7 +481,6 @@ public class TransformQuery<Transformed>
             transformedList.add(element);
           }
         }
-        
         try {
           field.set(result, transformedList);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/contentful/java/cda/TransformQuery.java
+++ b/src/main/java/com/contentful/java/cda/TransformQuery.java
@@ -459,9 +459,13 @@ public class TransformQuery<Transformed>
           transform(fieldEntry);
         }
 
-        field.set(result, instanceCache.get(fieldEntry.id()));
+        try {
+          field.set(result, instanceCache.get(fieldEntry.id()));
+        } catch (IllegalArgumentException e) {
+          // Field doesn't exist on the result object, skip it and continue
+        }
       } else if (value instanceof Collection) {
-        @SuppressWarnings("unchecked") final Collection<Object> collection = (Collection) value;
+        @SuppressWarnings("unchecked") final Collection<Object> collection = (Collection<Object>) value;
 
         final ArrayList<Object> transformedList = new ArrayList<>(collection.size());
         for (final Object element : collection) {
@@ -475,11 +479,19 @@ public class TransformQuery<Transformed>
           } else {
             transformedList.add(element);
           }
-
+        }
+        
+        try {
           field.set(result, transformedList);
+        } catch (IllegalArgumentException e) {
+          // Field doesn't exist on the result object, skip it and continue
         }
       } else {
-        field.set(result, value);
+        try {
+          field.set(result, value);
+        } catch (IllegalArgumentException e) {
+          // Field doesn't exist on the result object, skip it and continue
+        }
       }
     } catch (IllegalAccessException e) {
       throw new IllegalStateException("Cannot set custom field " + key + ".");


### PR DESCRIPTION
We have had the following issues arise a few times now:
- User updates a Content Model to add a new field
- User updates Content instances and add data for that new field
- Our application has not been updated to know about that new field and the SDK then blows up with this error:

```
processing failed: java.lang.IllegalArgumentException: Can not set com.angi.cms.model.content.components.layout.ComponentConfiguration field com.angi.cms.model.content.components.layout.PageLayoutComponent.componentConfiguration to com.google.gson.internal.LinkedTreeMap] with root cause",
  "logger_name": "org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[dispatcherServlet]",
  "thread_name": "http-nio-8080-exec-9",
  "level": "ERROR",
  "level_value": 40000,
  "stack_trace": "java.lang.IllegalArgumentException: Can not set com.angi.cms.model.content.components.layout.ComponentConfiguration field com.angi.cms.model.content.components.layout.PageLayoutComponent.componentConfiguration to com.google.gson.internal.LinkedTreeMap\n\tat java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167)\n\tat java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171)\n\tat java.base/jdk.internal.reflect.UnsafeObjectFieldAccessorImpl.set(UnsafeObjectFieldAccessorImpl.java:81)\n\tat java.base/java.lang.reflect.Field.set(Field.java:799)\n\tat com.contentful.java.cda.TransformQuery.transformFieldAnnotation(TransformQuery.java:482)\n\tat com.contentful.java.cda.TransformQuery.transform(TransformQuery.java:412)\n\tat com.contentful.java.cda.TransformQuery.transformFieldAnnotation(TransformQuery.java:471)\n\tat com.contentful.java.cda.TransformQuery.transform(TransformQuery.java:393)\n\tat com.contentful.java.cda.TransformQuery.transformFieldAnnotation(TransformQuery.java:459)\n\tat com.contentful.java.cda.TransformQuery.transform(TransformQuery.java:393)\n\tat com.contentful.java.cda.TransformQuery.access$000(TransformQuery.java:28)\n\tat com.contentful.java.cda.TransformQuery$4.apply(TransformQuery.java:321)\n\tat com.contentful.java.cda.TransformQuery$4.apply(TransformQuery.java:312)\n\tat io.reactivex.rxjava3.internal.operators.flowable.FlowableMap$MapSubscriber.onNext(FlowableMap.java:64)\n\tat 
  ```
  
  As the approach appears to be to parse the CDAEntry and _assume_ that a corresponding field exists on the Result (DTO representation in our code), it opens up the opportunity for this to potentially happen.
  
  This suggestion is to ignore those exceptions and continue on with what we do know how to handle.  I don't believe we should have to denote EVERY single field explicitly on our side to have the CDAClient transform correctly.
  
  If this is not desired, perhaps this can be gated behind a property on the CDAClient to let users decide?  I'm also open to proper logging behavior for this as I do not see much logging within this client for situations like thi.