### PR TITLE
fix: assign logSensitiveData in CDAHttpException constructor before it is used

### DIFF
--- a/src/main/java/com/contentful/java/cda/CDAHttpException.java
+++ b/src/main/java/com/contentful/java/cda/CDAHttpException.java
@@ -36,9 +36,9 @@ public class CDAHttpException extends RuntimeException {
     super(response.message());
     this.request = request;
     this.response = response;
+    this.logSensitiveData = logSensitiveData;
     this.responseBody = readResponseBody(response);
     this.stringRepresentation = createString();
-    this.logSensitiveData = logSensitiveData;
   }
 
   private String readResponseBody(Response response) {


### PR DESCRIPTION
The createString method is called inside the constructor and makes use of the logSensitiveData variable. Because that variable is assigned after the function call it is always false.